### PR TITLE
add match_ty based on cast_fns

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -41,23 +41,62 @@ impl<T: ?Sized> CastToken<T> {
     }
 }
 
+macro_rules! impl_try_cast_for_token {
+    ($from:ty, $to:ty) => {
+        #[inline(always)]
+        fn try_cast(&self, value: $from) -> Result<$to, $from> {
+            if self.can_cast() {
+                Ok(unsafe { Self::unchecked_to(value) })
+            } else {
+                Err(value)
+            }
+        }
+
+        #[inline(always)]
+        fn try_cast_from(&self, value: $to) -> Result<$from, $to> {
+            if self.can_cast() {
+                Ok(unsafe { Self::unchecked_from(value) })
+            } else {
+                Err(value)
+            }
+        }
+
+        #[inline(always)]
+        fn get_cast_fns(&self) -> Option<(fn($to) -> $from, fn($from) -> $to)> {
+            if self.can_cast() {
+                Some((Self::_from, Self::_to))
+            } else {
+                None
+            }
+        }
+
+        #[inline(always)]
+        fn _from(v: $to) -> $from {
+            unsafe { Self::unchecked_from(v) }
+        }
+
+        #[inline(always)]
+        fn _to(v: $from) -> $to {
+            unsafe { Self::unchecked_to(v) }
+        }
+
+        #[inline(always)]
+        fn cast_method(&self) -> Option<CastMethod> {
+            if self.can_cast() {
+                Some(Self::CAST_METHOD)
+            } else {
+                None
+            }
+        }
+    };
+}
+
 /// Supporting trait for autoderef specialization on mutable references to lifetime-free
 /// types.
 pub trait TryCastMutLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
-    #[inline(always)]
-    fn try_cast(&self, value: &'a mut T) -> Result<&'a mut U, &'a mut T> {
-        // SAFETY: See comments on safety in `TryCastLifetimeFree`.
+    const CAST_METHOD: CastMethod = CastMethod::MutLifetimeFree;
 
-        if type_eq_non_static::<T, U>() {
-            // Pointer casts are not allowed here since the compiler can't prove
-            // that `&mut T` and `&mut U` have the same kind of associated
-            // pointer data if they are fat pointers. But we know they are
-            // identical, so we use a transmute.
-            Ok(unsafe { transmute_unchecked::<&mut T, &mut U>(value) })
-        } else {
-            Err(value)
-        }
-    }
+    impl_try_cast_for_token!(&'a mut T, &'a mut U);
 
     #[inline(always)]
     fn can_cast(&self) -> bool {
@@ -65,12 +104,25 @@ pub trait TryCastMutLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
     }
 
     #[inline(always)]
-    fn cast_method(&self) -> Option<CastMethod> {
-        if self.can_cast() {
-            Some(CastMethod::MutLifetimeFree)
-        } else {
-            None
-        }
+    unsafe fn unchecked_to(value: &'a mut T) -> &'a mut U {
+        // SAFETY: See comments on safety in `TryCastLifetimeFree`.
+        //
+        // Pointer casts are not allowed here since the compiler can't prove
+        // that `&mut T` and `&mut U` have the same kind of associated
+        // pointer data if they are fat pointers. But we know they are
+        // identical, so we use a transmute.
+        unsafe { transmute_unchecked::<&mut T, &mut U>(value) }
+    }
+
+    #[inline(always)]
+    unsafe fn unchecked_from(value: &'a mut U) -> &'a mut T {
+        // SAFETY: See comments on safety in `TryCastLifetimeFree`.
+        //
+        // Pointer casts are not allowed here since the compiler can't prove
+        // that `&mut T` and `&mut U` have the same kind of associated
+        // pointer data if they are fat pointers. But we know they are
+        // identical, so we use a transmute.
+        unsafe { transmute_unchecked::<&mut U, &mut T>(value) }
     }
 }
 
@@ -82,20 +134,9 @@ impl<'a, T: ?Sized, U: LifetimeFree + ?Sized> TryCastMutLifetimeFree<'a, T, U>
 /// Supporting trait for autoderef specialization on references to lifetime-free
 /// types.
 pub trait TryCastRefLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
-    #[inline(always)]
-    fn try_cast(&self, value: &'a T) -> Result<&'a U, &'a T> {
-        // SAFETY: See comments on safety in `TryCastLifetimeFree`.
+    const CAST_METHOD: CastMethod = CastMethod::RefLifetimeFree;
 
-        if type_eq_non_static::<T, U>() {
-            // Pointer casts are not allowed here since the compiler can't prove
-            // that `&T` and `&U` have the same kind of associated pointer data if
-            // they are fat pointers. But we know they are identical, so we use
-            // a transmute.
-            Ok(unsafe { transmute_unchecked::<&T, &U>(value) })
-        } else {
-            Err(value)
-        }
-    }
+    impl_try_cast_for_token!(&'a T, &'a U);
 
     #[inline(always)]
     fn can_cast(&self) -> bool {
@@ -103,12 +144,25 @@ pub trait TryCastRefLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
     }
 
     #[inline(always)]
-    fn cast_method(&self) -> Option<CastMethod> {
-        if self.can_cast() {
-            Some(CastMethod::RefLifetimeFree)
-        } else {
-            None
-        }
+    unsafe fn unchecked_to(value: &'a T) -> &'a U {
+        // SAFETY: See comments on safety in `TryCastLifetimeFree`.
+        //
+        // Pointer casts are not allowed here since the compiler can't prove
+        // that `&T` and `&U` have the same kind of associated pointer data if
+        // they are fat pointers. But we know they are identical, so we use
+        // a transmute.
+        unsafe { transmute_unchecked::<&T, &U>(value) }
+    }
+
+    #[inline(always)]
+    unsafe fn unchecked_from(value: &'a U) -> &'a T {
+        // SAFETY: See comments on safety in `TryCastLifetimeFree`.
+        //
+        // Pointer casts are not allowed here since the compiler can't prove
+        // that `&T` and `&U` have the same kind of associated pointer data if
+        // they are fat pointers. But we know they are identical, so we use
+        // a transmute.
+        unsafe { transmute_unchecked::<&U, &T>(value) }
     }
 }
 
@@ -119,8 +173,17 @@ impl<'a, T: ?Sized, U: LifetimeFree + ?Sized> TryCastRefLifetimeFree<'a, T, U>
 
 /// Supporting trait for autoderef specialization on lifetime-free types.
 pub trait TryCastOwnedLifetimeFree<T, U: LifetimeFree> {
+    const CAST_METHOD: CastMethod = CastMethod::OwnedLifetimeFree;
+
+    impl_try_cast_for_token!(T, U);
+
     #[inline(always)]
-    fn try_cast(&self, value: T) -> Result<U, T> {
+    fn can_cast(&self) -> bool {
+        type_eq_non_static::<T, U>()
+    }
+
+    #[inline(always)]
+    unsafe fn unchecked_to(value: T) -> U {
         // SAFETY: If `U` is lifetime-free, and the base types of `T` and `U`
         // are equal, then `T` is also lifetime-free. Therefore `T` and `U` are
         // strictly identical and it is safe to cast a `T` into a `U`.
@@ -129,26 +192,20 @@ pub trait TryCastOwnedLifetimeFree<T, U: LifetimeFree> {
         // checked statically. `LifetimeFree` is an unsafe trait implemented for
         // individual types, so the burden of verifying that a type is indeed
         // lifetime-free is on the implementer.
-
-        if type_eq_non_static::<T, U>() {
-            Ok(unsafe { transmute_unchecked::<T, U>(value) })
-        } else {
-            Err(value)
-        }
+        unsafe { transmute_unchecked::<T, U>(value) }
     }
 
     #[inline(always)]
-    fn can_cast(&self) -> bool {
-        type_eq_non_static::<T, U>()
-    }
-
-    #[inline(always)]
-    fn cast_method(&self) -> Option<CastMethod> {
-        if self.can_cast() {
-            Some(CastMethod::OwnedLifetimeFree)
-        } else {
-            None
-        }
+    unsafe fn unchecked_from(value: U) -> T {
+        // SAFETY: If `U` is lifetime-free, and the base types of `T` and `U`
+        // are equal, then `T` is also lifetime-free. Therefore `T` and `U` are
+        // strictly identical and it is safe to cast a `U` into a `T`.
+        //
+        // We know that `U` is lifetime-free because of the `LifetimeFree` trait
+        // checked statically. `LifetimeFree` is an unsafe trait implemented for
+        // individual types, so the burden of verifying that a type is indeed
+        // lifetime-free is on the implementer.
+        unsafe { transmute_unchecked::<U, T>(value) }
     }
 }
 
@@ -156,32 +213,28 @@ impl<T, U: LifetimeFree> TryCastOwnedLifetimeFree<T, U> for &&&&&(CastToken<T>, 
 
 /// Supporting trait for autoderef specialization on mutable slices.
 pub trait TryCastSliceMut<'a, T: 'static, U: 'static> {
-    /// Attempt to cast a generic mutable slice to a given type if the types are
-    /// equal.
-    ///
-    /// The reference does not have to be static as long as the item type is
-    /// static.
-    #[inline(always)]
-    fn try_cast(&self, value: &'a mut [T]) -> Result<&'a mut [U], &'a mut [T]> {
-        if type_eq::<T, U>() {
-            Ok(unsafe { &mut *(value as *mut [T] as *mut [U]) })
-        } else {
-            Err(value)
-        }
-    }
+    const CAST_METHOD: CastMethod = CastMethod::SliceMut;
+
+    impl_try_cast_for_token!(&'a mut [T], &'a mut [U]);
 
     #[inline(always)]
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
     }
 
+    /// Attempt to cast a generic mutable slice to a given type if the types are
+    /// equal.
+    ///
+    /// The reference does not have to be static as long as the item type is
+    /// static.
     #[inline(always)]
-    fn cast_method(&self) -> Option<CastMethod> {
-        if self.can_cast() {
-            Some(CastMethod::SliceMut)
-        } else {
-            None
-        }
+    unsafe fn unchecked_to(value: &'a mut [T]) -> &'a mut [U] {
+        unsafe { &mut *(value as *mut [T] as *mut [U]) }
+    }
+
+    #[inline(always)]
+    unsafe fn unchecked_from(value: &'a mut [U]) -> &'a mut [T] {
+        unsafe { &mut *(value as *mut [U] as *mut [T]) }
     }
 }
 
@@ -192,31 +245,27 @@ impl<'a, T: 'static, U: 'static> TryCastSliceMut<'a, T, U>
 
 /// Supporting trait for autoderef specialization on slices.
 pub trait TryCastSliceRef<'a, T: 'static, U: 'static> {
-    /// Attempt to cast a generic slice to a given type if the types are equal.
-    ///
-    /// The reference does not have to be static as long as the item type is
-    /// static.
-    #[inline(always)]
-    fn try_cast(&self, value: &'a [T]) -> Result<&'a [U], &'a [T]> {
-        if type_eq::<T, U>() {
-            Ok(unsafe { &*(value as *const [T] as *const [U]) })
-        } else {
-            Err(value)
-        }
-    }
+    const CAST_METHOD: CastMethod = CastMethod::SliceRef;
+
+    impl_try_cast_for_token!(&'a [T], &'a [U]);
 
     #[inline(always)]
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
     }
 
+    /// Attempt to cast a generic slice to a given type if the types are equal.
+    ///
+    /// The reference does not have to be static as long as the item type is
+    /// static.
     #[inline(always)]
-    fn cast_method(&self) -> Option<CastMethod> {
-        if self.can_cast() {
-            Some(CastMethod::SliceRef)
-        } else {
-            None
-        }
+    unsafe fn unchecked_to(value: &'a [T]) -> &'a [U] {
+        unsafe { &*(value as *const [T] as *const [U]) }
+    }
+
+    #[inline(always)]
+    unsafe fn unchecked_from(value: &'a [U]) -> &'a [T] {
+        unsafe { &*(value as *const [U] as *const [T]) }
     }
 }
 
@@ -227,32 +276,28 @@ impl<'a, T: 'static, U: 'static> TryCastSliceRef<'a, T, U>
 
 /// Supporting trait for autoderef specialization on mutable references.
 pub trait TryCastMut<'a, T: 'static, U: 'static> {
-    /// Attempt to cast a generic mutable reference to a given type if the types
-    /// are equal.
-    ///
-    /// The reference does not have to be static as long as the reference target
-    /// type is static.
-    #[inline(always)]
-    fn try_cast(&self, value: &'a mut T) -> Result<&'a mut U, &'a mut T> {
-        if type_eq::<T, U>() {
-            Ok(unsafe { &mut *(value as *mut T as *mut U) })
-        } else {
-            Err(value)
-        }
-    }
+    const CAST_METHOD: CastMethod = CastMethod::Mut;
+
+    impl_try_cast_for_token!(&'a mut T, &'a mut U);
 
     #[inline(always)]
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
     }
 
+    /// Attempt to cast a generic mutable reference to a given type if the types
+    /// are equal.
+    ///
+    /// The reference does not have to be static as long as the reference target
+    /// type is static.
     #[inline(always)]
-    fn cast_method(&self) -> Option<CastMethod> {
-        if self.can_cast() {
-            Some(CastMethod::Mut)
-        } else {
-            None
-        }
+    unsafe fn unchecked_to(value: &'a mut T) -> &'a mut U {
+        unsafe { &mut *(value as *mut T as *mut U) }
+    }
+
+    #[inline(always)]
+    unsafe fn unchecked_from(value: &'a mut U) -> &'a mut T {
+        unsafe { &mut *(value as *mut U as *mut T) }
     }
 }
 
@@ -263,32 +308,26 @@ impl<'a, T: 'static, U: 'static> TryCastMut<'a, T, U>
 
 /// Supporting trait for autoderef specialization on references.
 pub trait TryCastRef<'a, T: 'static, U: 'static> {
-    /// Attempt to cast a generic reference to a given type if the types are
-    /// equal.
-    ///
-    /// The reference does not have to be static as long as the reference target
-    /// type is static.
-    #[inline(always)]
-    fn try_cast(&self, value: &'a T) -> Result<&'a U, &'a T> {
-        if type_eq::<T, U>() {
-            Ok(unsafe { &*(value as *const T as *const U) })
-        } else {
-            Err(value)
-        }
-    }
+    const CAST_METHOD: CastMethod = CastMethod::Ref;
+
+    impl_try_cast_for_token!(&'a T, &'a U);
 
     #[inline(always)]
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
     }
 
-    #[inline(always)]
-    fn cast_method(&self) -> Option<CastMethod> {
-        if self.can_cast() {
-            Some(CastMethod::Ref)
-        } else {
-            None
-        }
+    /// Attempt to cast a generic reference to a given type if the types are
+    /// equal.
+    ///
+    /// The reference does not have to be static as long as the reference target
+    /// type is static.
+    unsafe fn unchecked_to(value: &'a T) -> &'a U {
+        unsafe { &*(value as *const T as *const U) }
+    }
+
+    unsafe fn unchecked_from(value: &'a U) -> &'a T {
+        unsafe { &*(value as *const U as *const T) }
     }
 }
 
@@ -296,28 +335,22 @@ impl<'a, T: 'static, U: 'static> TryCastRef<'a, T, U> for &(CastToken<&'a T>, Ca
 
 /// Default trait for autoderef specialization.
 pub trait TryCastOwned<T: 'static, U: 'static> {
-    /// Attempt to cast a value to a given type if the types are equal.
-    #[inline(always)]
-    fn try_cast(&self, value: T) -> Result<U, T> {
-        if type_eq::<T, U>() {
-            Ok(unsafe { transmute_unchecked::<T, U>(value) })
-        } else {
-            Err(value)
-        }
-    }
+    const CAST_METHOD: CastMethod = CastMethod::Owned;
+
+    impl_try_cast_for_token!(T, U);
 
     #[inline(always)]
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
     }
 
-    #[inline(always)]
-    fn cast_method(&self) -> Option<CastMethod> {
-        if self.can_cast() {
-            Some(CastMethod::Owned)
-        } else {
-            None
-        }
+    /// Attempt to cast a value to a given type if the types are equal.
+    unsafe fn unchecked_to(value: T) -> U {
+        unsafe { transmute_unchecked::<T, U>(value) }
+    }
+
+    unsafe fn unchecked_from(value: U) -> T {
+        unsafe { transmute_unchecked::<U, T>(value) }
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -66,7 +66,11 @@ pub trait TryCastMutLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
 
     #[inline(always)]
     fn cast_method(&self) -> Option<CastMethod> {
-        self.can_cast().then_some(CastMethod::MutLifetimeFree)
+        if self.can_cast() {
+            Some(CastMethod::MutLifetimeFree)
+        } else {
+            None
+        }
     }
 }
 
@@ -100,7 +104,11 @@ pub trait TryCastRefLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
 
     #[inline(always)]
     fn cast_method(&self) -> Option<CastMethod> {
-        self.can_cast().then_some(CastMethod::RefLifetimeFree)
+        if self.can_cast() {
+            Some(CastMethod::RefLifetimeFree)
+        } else {
+            None
+        }
     }
 }
 
@@ -136,7 +144,11 @@ pub trait TryCastOwnedLifetimeFree<T, U: LifetimeFree> {
 
     #[inline(always)]
     fn cast_method(&self) -> Option<CastMethod> {
-        self.can_cast().then_some(CastMethod::OwnedLifetimeFree)
+        if self.can_cast() {
+            Some(CastMethod::OwnedLifetimeFree)
+        } else {
+            None
+        }
     }
 }
 
@@ -165,7 +177,11 @@ pub trait TryCastSliceMut<'a, T: 'static, U: 'static> {
 
     #[inline(always)]
     fn cast_method(&self) -> Option<CastMethod> {
-        self.can_cast().then_some(CastMethod::SliceMut)
+        if self.can_cast() {
+            Some(CastMethod::SliceMut)
+        } else {
+            None
+        }
     }
 }
 
@@ -196,7 +212,11 @@ pub trait TryCastSliceRef<'a, T: 'static, U: 'static> {
 
     #[inline(always)]
     fn cast_method(&self) -> Option<CastMethod> {
-        self.can_cast().then_some(CastMethod::SliceRef)
+        if self.can_cast() {
+            Some(CastMethod::SliceRef)
+        } else {
+            None
+        }
     }
 }
 
@@ -228,7 +248,11 @@ pub trait TryCastMut<'a, T: 'static, U: 'static> {
 
     #[inline(always)]
     fn cast_method(&self) -> Option<CastMethod> {
-        self.can_cast().then_some(CastMethod::Mut)
+        if self.can_cast() {
+            Some(CastMethod::Mut)
+        } else {
+            None
+        }
     }
 }
 
@@ -260,7 +284,11 @@ pub trait TryCastRef<'a, T: 'static, U: 'static> {
 
     #[inline(always)]
     fn cast_method(&self) -> Option<CastMethod> {
-        self.can_cast().then_some(CastMethod::Ref)
+        if self.can_cast() {
+            Some(CastMethod::Ref)
+        } else {
+            None
+        }
     }
 }
 
@@ -285,7 +313,11 @@ pub trait TryCastOwned<T: 'static, U: 'static> {
 
     #[inline(always)]
     fn cast_method(&self) -> Option<CastMethod> {
-        self.can_cast().then_some(CastMethod::Owned)
+        if self.can_cast() {
+            Some(CastMethod::Owned)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -46,6 +46,11 @@ pub trait TryCastMutLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
             Err(value)
         }
     }
+
+    #[inline(always)]
+    fn can_cast(&self) -> bool {
+        type_eq_non_static::<T, U>()
+    }
 }
 
 impl<'a, T: ?Sized, U: LifetimeFree + ?Sized> TryCastMutLifetimeFree<'a, T, U>
@@ -69,6 +74,11 @@ pub trait TryCastRefLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
         } else {
             Err(value)
         }
+    }
+
+    #[inline(always)]
+    fn can_cast(&self) -> bool {
+        type_eq_non_static::<T, U>()
     }
 }
 
@@ -96,6 +106,11 @@ pub trait TryCastOwnedLifetimeFree<T, U: LifetimeFree> {
             Err(value)
         }
     }
+
+    #[inline(always)]
+    fn can_cast(&self) -> bool {
+        type_eq_non_static::<T, U>()
+    }
 }
 
 impl<T, U: LifetimeFree> TryCastOwnedLifetimeFree<T, U> for &&&&&(CastToken<T>, CastToken<U>) {}
@@ -114,6 +129,11 @@ pub trait TryCastSliceMut<'a, T: 'static, U: 'static> {
         } else {
             Err(value)
         }
+    }
+
+    #[inline(always)]
+    fn can_cast(&self) -> bool {
+        type_eq::<T, U>()
     }
 }
 
@@ -135,6 +155,11 @@ pub trait TryCastSliceRef<'a, T: 'static, U: 'static> {
         } else {
             Err(value)
         }
+    }
+
+    #[inline(always)]
+    fn can_cast(&self) -> bool {
+        type_eq::<T, U>()
     }
 }
 
@@ -158,6 +183,11 @@ pub trait TryCastMut<'a, T: 'static, U: 'static> {
             Err(value)
         }
     }
+
+    #[inline(always)]
+    fn can_cast(&self) -> bool {
+        type_eq::<T, U>()
+    }
 }
 
 impl<'a, T: 'static, U: 'static> TryCastMut<'a, T, U>
@@ -180,6 +210,11 @@ pub trait TryCastRef<'a, T: 'static, U: 'static> {
             Err(value)
         }
     }
+
+    #[inline(always)]
+    fn can_cast(&self) -> bool {
+        type_eq::<T, U>()
+    }
 }
 
 impl<'a, T: 'static, U: 'static> TryCastRef<'a, T, U> for &(CastToken<&'a T>, CastToken<&'a U>) {}
@@ -195,6 +230,107 @@ pub trait TryCastOwned<T: 'static, U: 'static> {
             Err(value)
         }
     }
+
+    #[inline(always)]
+    fn can_cast(&self) -> bool {
+        type_eq::<T, U>()
+    }
 }
 
 impl<T: 'static, U: 'static> TryCastOwned<T, U> for (CastToken<T>, CastToken<U>) {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_cast() {
+        // TryCastOwned
+        fn try_cast_owned<T: Copy + 'static>(value: T, success: bool) {
+            let token = (CastToken::<T>::of(), CastToken::<i32>::of());
+            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!(token.try_cast(value).is_ok(), success);
+            assert_eq!(token.can_cast(), success);
+        }
+        try_cast_owned(42i32, true);
+        try_cast_owned(42u32, false);
+
+        // TryCastRef
+        fn try_cast_ref<T: 'static>(value: &T, success: bool) {
+            let token = (CastToken::<&T>::of(), CastToken::<&i32>::of());
+            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&token).can_cast(), success);
+        }
+        try_cast_ref(&42i32, true);
+        try_cast_ref(&42u32, false);
+
+        // TryCastMut
+        fn try_cast_mut<T: 'static>(value: &mut T, success: bool) {
+            let token = (CastToken::<&mut T>::of(), CastToken::<&mut i32>::of());
+            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&token).can_cast(), success);
+        }
+        try_cast_mut(&mut 42i32, true);
+        try_cast_mut(&mut 42u32, false);
+
+        // TryCastSliceRef
+        fn try_cast_slice_ref<T: 'static>(value: &[T], success: bool) {
+            let token = (CastToken::<&[T]>::of(), CastToken::<&[i32]>::of());
+            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&token).can_cast(), success);
+        }
+        try_cast_slice_ref(&[42i32], true);
+        try_cast_slice_ref(&[42u32], false);
+
+        // TryCastSliceMut
+        fn try_cast_slice_mut<T: 'static>(value: &mut [T], success: bool) {
+            let token = (CastToken::<&mut [T]>::of(), CastToken::<&mut [i32]>::of());
+            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&token).can_cast(), success);
+        }
+        try_cast_slice_mut(&mut [42i32], true);
+        try_cast_slice_mut(&mut [42u32], false);
+
+        // TryCastOwnedLifetimeFree
+        fn try_cast_owned_lifetime_free<T: Copy + LifetimeFree>(value: T, success: bool) {
+            let token = (CastToken::<T>::of(), CastToken::<i32>::of());
+            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&token).can_cast(), success);
+        }
+        try_cast_owned_lifetime_free(42i32, true);
+        try_cast_owned_lifetime_free(42u32, false);
+
+        // TryCastRefLifetimeFree
+        fn try_cast_ref_lifetime_free<T: LifetimeFree>(value: &T, success: bool) {
+            let token = (CastToken::<&T>::of(), CastToken::<&i32>::of());
+            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&token).can_cast(), success);
+        }
+        try_cast_ref_lifetime_free(&42i32, true);
+        try_cast_ref_lifetime_free(&42u32, false);
+
+        // TryCastMutLifetimeFree
+        fn try_cast_mut_lifetime_free<T: LifetimeFree>(value: &mut T, success: bool) {
+            let token = (CastToken::<&mut T>::of(), CastToken::<&mut i32>::of());
+            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
+            assert_eq!((&&&&&&&token).can_cast(), success);
+        }
+        try_cast_mut_lifetime_free(&mut 42i32, true);
+        try_cast_mut_lifetime_free(&mut 42u32, false);
+    }
+}

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -17,6 +17,18 @@ use core::marker::PhantomData;
 /// values. Used to select a cast implementation in macros.
 pub struct CastToken<T: ?Sized>(PhantomData<T>);
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CastMethod {
+    Owned,
+    Ref,
+    Mut,
+    SliceRef,
+    SliceMut,
+    OwnedLifetimeFree,
+    RefLifetimeFree,
+    MutLifetimeFree,
+}
+
 impl<T: ?Sized> CastToken<T> {
     /// Create a cast token for the given type of value.
     pub const fn of_val(_value: &T) -> Self {
@@ -51,6 +63,11 @@ pub trait TryCastMutLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
     fn can_cast(&self) -> bool {
         type_eq_non_static::<T, U>()
     }
+
+    #[inline(always)]
+    fn cast_method(&self) -> Option<CastMethod> {
+        self.can_cast().then_some(CastMethod::MutLifetimeFree)
+    }
 }
 
 impl<'a, T: ?Sized, U: LifetimeFree + ?Sized> TryCastMutLifetimeFree<'a, T, U>
@@ -79,6 +96,11 @@ pub trait TryCastRefLifetimeFree<'a, T: ?Sized, U: LifetimeFree + ?Sized> {
     #[inline(always)]
     fn can_cast(&self) -> bool {
         type_eq_non_static::<T, U>()
+    }
+
+    #[inline(always)]
+    fn cast_method(&self) -> Option<CastMethod> {
+        self.can_cast().then_some(CastMethod::RefLifetimeFree)
     }
 }
 
@@ -111,6 +133,11 @@ pub trait TryCastOwnedLifetimeFree<T, U: LifetimeFree> {
     fn can_cast(&self) -> bool {
         type_eq_non_static::<T, U>()
     }
+
+    #[inline(always)]
+    fn cast_method(&self) -> Option<CastMethod> {
+        self.can_cast().then_some(CastMethod::OwnedLifetimeFree)
+    }
 }
 
 impl<T, U: LifetimeFree> TryCastOwnedLifetimeFree<T, U> for &&&&&(CastToken<T>, CastToken<U>) {}
@@ -134,6 +161,11 @@ pub trait TryCastSliceMut<'a, T: 'static, U: 'static> {
     #[inline(always)]
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
+    }
+
+    #[inline(always)]
+    fn cast_method(&self) -> Option<CastMethod> {
+        self.can_cast().then_some(CastMethod::SliceMut)
     }
 }
 
@@ -160,6 +192,11 @@ pub trait TryCastSliceRef<'a, T: 'static, U: 'static> {
     #[inline(always)]
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
+    }
+
+    #[inline(always)]
+    fn cast_method(&self) -> Option<CastMethod> {
+        self.can_cast().then_some(CastMethod::SliceRef)
     }
 }
 
@@ -188,6 +225,11 @@ pub trait TryCastMut<'a, T: 'static, U: 'static> {
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
     }
+
+    #[inline(always)]
+    fn cast_method(&self) -> Option<CastMethod> {
+        self.can_cast().then_some(CastMethod::Mut)
+    }
 }
 
 impl<'a, T: 'static, U: 'static> TryCastMut<'a, T, U>
@@ -215,6 +257,11 @@ pub trait TryCastRef<'a, T: 'static, U: 'static> {
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
     }
+
+    #[inline(always)]
+    fn cast_method(&self) -> Option<CastMethod> {
+        self.can_cast().then_some(CastMethod::Ref)
+    }
 }
 
 impl<'a, T: 'static, U: 'static> TryCastRef<'a, T, U> for &(CastToken<&'a T>, CastToken<&'a U>) {}
@@ -235,6 +282,11 @@ pub trait TryCastOwned<T: 'static, U: 'static> {
     fn can_cast(&self) -> bool {
         type_eq::<T, U>()
     }
+
+    #[inline(always)]
+    fn cast_method(&self) -> Option<CastMethod> {
+        self.can_cast().then_some(CastMethod::Owned)
+    }
 }
 
 impl<T: 'static, U: 'static> TryCastOwned<T, U> for (CastToken<T>, CastToken<U>) {}
@@ -246,91 +298,115 @@ mod tests {
     #[test]
     fn test_try_cast() {
         // TryCastOwned
-        fn try_cast_owned<T: Copy + 'static>(value: T, success: bool) {
-            let token = (CastToken::<T>::of(), CastToken::<i32>::of());
+        fn try_cast_owned<T: Copy + 'static, U: 'static>(value: T, success: bool) {
+            let token = (CastToken::<T>::of(), CastToken::<U>::of());
+            let method = success.then_some(CastMethod::Owned);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).cast_method(), method);
             assert_eq!(token.try_cast(value).is_ok(), success);
             assert_eq!(token.can_cast(), success);
+            assert_eq!(token.cast_method(), method);
         }
-        try_cast_owned(42i32, true);
-        try_cast_owned(42u32, false);
+        try_cast_owned::<_, i32>(42i32, true);
+        try_cast_owned::<_, i32>(42u32, false);
 
         // TryCastRef
-        fn try_cast_ref<T: 'static>(value: &T, success: bool) {
-            let token = (CastToken::<&T>::of(), CastToken::<&i32>::of());
+        fn try_cast_ref<T: 'static, U: 'static>(value: &T, success: bool) {
+            let token = (CastToken::<&T>::of(), CastToken::<&U>::of());
+            let method = success.then_some(CastMethod::Ref);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).cast_method(), method);
             assert_eq!((&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&token).can_cast(), success);
+            assert_eq!((&&token).cast_method(), method);
         }
-        try_cast_ref(&42i32, true);
-        try_cast_ref(&42u32, false);
+        try_cast_ref::<_, i32>(&42i32, true);
+        try_cast_ref::<_, i32>(&42u32, false);
 
         // TryCastMut
-        fn try_cast_mut<T: 'static>(value: &mut T, success: bool) {
-            let token = (CastToken::<&mut T>::of(), CastToken::<&mut i32>::of());
+        fn try_cast_mut<T: 'static, U: 'static>(value: &mut T, success: bool) {
+            let token = (CastToken::<&mut T>::of(), CastToken::<&mut U>::of());
+            let method = success.then_some(CastMethod::Mut);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).cast_method(), method);
             assert_eq!((&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&token).can_cast(), success);
+            assert_eq!((&&token).cast_method(), method);
         }
-        try_cast_mut(&mut 42i32, true);
-        try_cast_mut(&mut 42u32, false);
+        try_cast_mut::<_, i32>(&mut 42i32, true);
+        try_cast_mut::<_, i32>(&mut 42u32, false);
 
         // TryCastSliceRef
-        fn try_cast_slice_ref<T: 'static>(value: &[T], success: bool) {
-            let token = (CastToken::<&[T]>::of(), CastToken::<&[i32]>::of());
+        fn try_cast_slice_ref<T: 'static, U: 'static>(value: &[T], success: bool) {
+            let token = (CastToken::<&[T]>::of(), CastToken::<&[U]>::of());
+            let method = success.then_some(CastMethod::SliceRef);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).cast_method(), method);
             assert_eq!((&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&token).can_cast(), success);
+            assert_eq!((&&&token).cast_method(), method);
         }
-        try_cast_slice_ref(&[42i32], true);
-        try_cast_slice_ref(&[42u32], false);
+        try_cast_slice_ref::<_, i32>(&[42i32], true);
+        try_cast_slice_ref::<_, i32>(&[42u32], false);
 
         // TryCastSliceMut
-        fn try_cast_slice_mut<T: 'static>(value: &mut [T], success: bool) {
-            let token = (CastToken::<&mut [T]>::of(), CastToken::<&mut [i32]>::of());
+        fn try_cast_slice_mut<T: 'static, U: 'static>(value: &mut [T], success: bool) {
+            let token = (CastToken::<&mut [T]>::of(), CastToken::<&mut [U]>::of());
+            let method = success.then_some(CastMethod::SliceMut);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).cast_method(), method);
             assert_eq!((&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&token).can_cast(), success);
+            assert_eq!((&&&&token).cast_method(), method);
         }
-        try_cast_slice_mut(&mut [42i32], true);
-        try_cast_slice_mut(&mut [42u32], false);
+        try_cast_slice_mut::<_, i32>(&mut [42i32], true);
+        try_cast_slice_mut::<_, i32>(&mut [42u32], false);
 
         // TryCastOwnedLifetimeFree
-        fn try_cast_owned_lifetime_free<T: Copy + LifetimeFree>(value: T, success: bool) {
-            let token = (CastToken::<T>::of(), CastToken::<i32>::of());
+        fn try_cast_owned_lifetime_free<T: Copy + LifetimeFree, U: LifetimeFree>(value: T, success: bool) {
+            let token = (CastToken::<T>::of(), CastToken::<U>::of());
+            let method = success.then_some(CastMethod::OwnedLifetimeFree);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).cast_method(), method);
             assert_eq!((&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&token).cast_method(), method);
         }
-        try_cast_owned_lifetime_free(42i32, true);
-        try_cast_owned_lifetime_free(42u32, false);
+        try_cast_owned_lifetime_free::<_, i32>(42i32, true);
+        try_cast_owned_lifetime_free::<_, i32>(42u32, false);
 
         // TryCastRefLifetimeFree
-        fn try_cast_ref_lifetime_free<T: LifetimeFree>(value: &T, success: bool) {
-            let token = (CastToken::<&T>::of(), CastToken::<&i32>::of());
+        fn try_cast_ref_lifetime_free<T: LifetimeFree, U: LifetimeFree>(value: &T, success: bool) {
+            let token = (CastToken::<&T>::of(), CastToken::<&U>::of());
+            let method = success.then_some(CastMethod::RefLifetimeFree);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).cast_method(), method);
             assert_eq!((&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&token).cast_method(), method);
         }
-        try_cast_ref_lifetime_free(&42i32, true);
-        try_cast_ref_lifetime_free(&42u32, false);
+        try_cast_ref_lifetime_free::<_, i32>(&42i32, true);
+        try_cast_ref_lifetime_free::<_, i32>(&42u32, false);
 
         // TryCastMutLifetimeFree
-        fn try_cast_mut_lifetime_free<T: LifetimeFree>(value: &mut T, success: bool) {
-            let token = (CastToken::<&mut T>::of(), CastToken::<&mut i32>::of());
+        fn try_cast_mut_lifetime_free<T: LifetimeFree, U: LifetimeFree>(value: &mut T, success: bool) {
+            let token = (CastToken::<&mut T>::of(), CastToken::<&mut U>::of());
+            let method = success.then_some(CastMethod::MutLifetimeFree);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).cast_method(), method);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
+            assert_eq!((&&&&&&&token).cast_method(), method);
         }
-        try_cast_mut_lifetime_free(&mut 42i32, true);
-        try_cast_mut_lifetime_free(&mut 42u32, false);
+        try_cast_mut_lifetime_free::<_, i32>(&mut 42i32, true);
+        try_cast_mut_lifetime_free::<_, i32>(&mut 42u32, false);
     }
 }

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -327,15 +327,29 @@ impl<T: 'static, U: 'static> TryCastOwned<T, U> for (CastToken<T>, CastToken<U>)
 mod tests {
     use super::*;
 
+    macro_rules! dispatch {
+        ($value:expr) => {
+            (&&&&&&&$value)
+        };
+    }
+
+    fn then_some<T>(b: bool, v: T) -> Option<T> {
+        if b {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     #[test]
     fn test_try_cast() {
         // TryCastOwned
         fn try_cast_owned<T: Copy + 'static, U: 'static>(value: T, success: bool) {
             let token = (CastToken::<T>::of(), CastToken::<U>::of());
-            let method = success.then_some(CastMethod::Owned);
-            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
-            assert_eq!((&&&&&&&token).can_cast(), success);
-            assert_eq!((&&&&&&&token).cast_method(), method);
+            let method = then_some(success, CastMethod::Owned);
+            assert_eq!(dispatch!(token).try_cast(value).is_ok(), success);
+            assert_eq!(dispatch!(token).can_cast(), success);
+            assert_eq!(dispatch!(token).cast_method(), method);
             assert_eq!(token.try_cast(value).is_ok(), success);
             assert_eq!(token.can_cast(), success);
             assert_eq!(token.cast_method(), method);
@@ -346,10 +360,11 @@ mod tests {
         // TryCastRef
         fn try_cast_ref<T: 'static, U: 'static>(value: &T, success: bool) {
             let token = (CastToken::<&T>::of(), CastToken::<&U>::of());
-            let method = success.then_some(CastMethod::Ref);
-            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
-            assert_eq!((&&&&&&&token).can_cast(), success);
-            assert_eq!((&&&&&&&token).cast_method(), method);
+            let method = then_some(success, CastMethod::Ref);
+            assert_eq!(dispatch!(token).try_cast(value).is_ok(), success);
+            assert_eq!(dispatch!(token).can_cast(), success);
+            assert_eq!(dispatch!(token).cast_method(), method);
+            // I don't know why the double reference is needed here, but it is.
             assert_eq!((&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&token).can_cast(), success);
             assert_eq!((&&token).cast_method(), method);
@@ -360,10 +375,10 @@ mod tests {
         // TryCastMut
         fn try_cast_mut<T: 'static, U: 'static>(value: &mut T, success: bool) {
             let token = (CastToken::<&mut T>::of(), CastToken::<&mut U>::of());
-            let method = success.then_some(CastMethod::Mut);
-            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
-            assert_eq!((&&&&&&&token).can_cast(), success);
-            assert_eq!((&&&&&&&token).cast_method(), method);
+            let method = then_some(success, CastMethod::Mut);
+            assert_eq!(dispatch!(token).try_cast(value).is_ok(), success);
+            assert_eq!(dispatch!(token).can_cast(), success);
+            assert_eq!(dispatch!(token).cast_method(), method);
             assert_eq!((&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&token).can_cast(), success);
             assert_eq!((&&token).cast_method(), method);
@@ -374,10 +389,10 @@ mod tests {
         // TryCastSliceRef
         fn try_cast_slice_ref<T: 'static, U: 'static>(value: &[T], success: bool) {
             let token = (CastToken::<&[T]>::of(), CastToken::<&[U]>::of());
-            let method = success.then_some(CastMethod::SliceRef);
-            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
-            assert_eq!((&&&&&&&token).can_cast(), success);
-            assert_eq!((&&&&&&&token).cast_method(), method);
+            let method = then_some(success, CastMethod::SliceRef);
+            assert_eq!(dispatch!(token).try_cast(value).is_ok(), success);
+            assert_eq!(dispatch!(token).can_cast(), success);
+            assert_eq!(dispatch!(token).cast_method(), method);
             assert_eq!((&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&token).can_cast(), success);
             assert_eq!((&&&token).cast_method(), method);
@@ -388,10 +403,10 @@ mod tests {
         // TryCastSliceMut
         fn try_cast_slice_mut<T: 'static, U: 'static>(value: &mut [T], success: bool) {
             let token = (CastToken::<&mut [T]>::of(), CastToken::<&mut [U]>::of());
-            let method = success.then_some(CastMethod::SliceMut);
-            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
-            assert_eq!((&&&&&&&token).can_cast(), success);
-            assert_eq!((&&&&&&&token).cast_method(), method);
+            let method = then_some(success, CastMethod::SliceMut);
+            assert_eq!(dispatch!(token).try_cast(value).is_ok(), success);
+            assert_eq!(dispatch!(token).can_cast(), success);
+            assert_eq!(dispatch!(token).cast_method(), method);
             assert_eq!((&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&token).can_cast(), success);
             assert_eq!((&&&&token).cast_method(), method);
@@ -402,10 +417,10 @@ mod tests {
         // TryCastOwnedLifetimeFree
         fn try_cast_owned_lifetime_free<T: Copy + LifetimeFree, U: LifetimeFree>(value: T, success: bool) {
             let token = (CastToken::<T>::of(), CastToken::<U>::of());
-            let method = success.then_some(CastMethod::OwnedLifetimeFree);
-            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
-            assert_eq!((&&&&&&&token).can_cast(), success);
-            assert_eq!((&&&&&&&token).cast_method(), method);
+            let method = then_some(success, CastMethod::OwnedLifetimeFree);
+            assert_eq!(dispatch!(token).try_cast(value).is_ok(), success);
+            assert_eq!(dispatch!(token).can_cast(), success);
+            assert_eq!(dispatch!(token).cast_method(), method);
             assert_eq!((&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&token).can_cast(), success);
             assert_eq!((&&&&&token).cast_method(), method);
@@ -416,10 +431,10 @@ mod tests {
         // TryCastRefLifetimeFree
         fn try_cast_ref_lifetime_free<T: LifetimeFree, U: LifetimeFree>(value: &T, success: bool) {
             let token = (CastToken::<&T>::of(), CastToken::<&U>::of());
-            let method = success.then_some(CastMethod::RefLifetimeFree);
-            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
-            assert_eq!((&&&&&&&token).can_cast(), success);
-            assert_eq!((&&&&&&&token).cast_method(), method);
+            let method = then_some(success, CastMethod::RefLifetimeFree);
+            assert_eq!(dispatch!(token).try_cast(value).is_ok(), success);
+            assert_eq!(dispatch!(token).can_cast(), success);
+            assert_eq!(dispatch!(token).cast_method(), method);
             assert_eq!((&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&token).can_cast(), success);
             assert_eq!((&&&&&&token).cast_method(), method);
@@ -430,10 +445,10 @@ mod tests {
         // TryCastMutLifetimeFree
         fn try_cast_mut_lifetime_free<T: LifetimeFree, U: LifetimeFree>(value: &mut T, success: bool) {
             let token = (CastToken::<&mut T>::of(), CastToken::<&mut U>::of());
-            let method = success.then_some(CastMethod::MutLifetimeFree);
-            assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
-            assert_eq!((&&&&&&&token).can_cast(), success);
-            assert_eq!((&&&&&&&token).cast_method(), method);
+            let method = then_some(success, CastMethod::MutLifetimeFree);
+            assert_eq!(dispatch!(token).try_cast(value).is_ok(), success);
+            assert_eq!(dispatch!(token).can_cast(), success);
+            assert_eq!(dispatch!(token).cast_method(), method);
             assert_eq!((&&&&&&&token).try_cast(value).is_ok(), success);
             assert_eq!((&&&&&&&token).can_cast(), success);
             assert_eq!((&&&&&&&token).cast_method(), method);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,6 +206,74 @@ macro_rules! cast {
     };
 }
 
+/// Check if a value can be cast to a given concrete type.
+/// The value would equal to `cast!(value, Type).is_ok()`.
+///
+/// The macro is useful when a value is not `Copy` or heavy to create,
+/// and you want to avoid moving it.
+///
+/// # Examples
+///
+/// ```
+/// # use castaway::can_cast;
+///
+/// assert!(!can_cast!(u8, u16));
+/// assert!(can_cast!(u8, u8));
+/// ```
+#[macro_export]
+macro_rules! can_cast {
+    ($T:ty, $U:ty) => {{
+        #[allow(unused_imports)]
+        use $crate::internal::*;
+
+        // Here we are using an _autoderef specialization_ technique, see notes in [`cast!`]
+        let src_token = CastToken::<$T>::of();
+        let dest_token = CastToken::<$U>::of();
+
+        // Note: The number of references added here must be kept in sync with
+        // the largest number of references used by any trait implementation in
+        // the internal module.
+        let result: bool = (&&&&&&&(src_token, dest_token)).can_cast();
+
+        result
+    }};
+}
+
+/// Check if a value can be cast to a given concrete type.
+/// The value would equal to `cast!(value, Type).is_ok()`.
+///
+/// The macro is useful when a value is not `Copy` or heavy to create,
+/// and you want to avoid moving it.
+///
+/// # Examples
+///
+/// ```
+/// # use castaway::get_cast_fns;
+///
+/// assert!(get_cast_fns!(u8, u16).is_none());
+/// let (from, to) = get_cast_fns!(u8, u8).unwrap();
+/// assert_eq!(from(42u8), 42u8);
+/// assert_eq!(to(42u8), 42u8);
+/// ```
+#[macro_export]
+macro_rules! get_cast_fns {
+    ($T:ty, $U:ty) => {{
+        #[allow(unused_imports)]
+        use $crate::internal::*;
+
+        // Here we are using an _autoderef specialization_ technique, see notes in [`cast!`]
+        let src_token = CastToken::<$T>::of();
+        let dest_token = CastToken::<$U>::of();
+
+        // Note: The number of references added here must be kept in sync with
+        // the largest number of references used by any trait implementation in
+        // the internal module.
+        let result: Option<(fn($U) -> $T, fn($T) -> $U)> = (&&&&&&&(src_token, dest_token)).get_cast_fns();
+
+        result
+    }};
+}
+
 /// Match the result of an expression against multiple concrete types.
 ///
 /// You can write multiple match arms in the following syntax:
@@ -282,6 +350,42 @@ macro_rules! match_type {
         let $pat = $value;
         $branch
     }};
+}
+
+#[macro_export]
+macro_rules! match_ty {
+    ($from:ty, {
+        $to:ty $(| $to_tail:ty)* => $branch:expr,
+        $($tail:tt)*
+    }) => {
+        $crate::match_ty!($from, {
+            | $to => $branch,
+            $(| $to_tail:ty => $branch,)*
+            $($tail)*
+        });
+    };
+
+    ($from:ty, {
+        | $to:ty $(| $to_tail:ty)* => $branch:expr,
+        $($tail:tt)*
+    }) => {{
+        if let Some((from, to)) = get_cast_fns!($from, $to) {
+            $branch
+        } else {
+            $crate::match_ty!($from, {
+                $(| $to_tail:ty => $branch,)*
+                $($tail)*
+            });
+        }
+    }};
+
+    ($from:ty, {
+        $pat:pat => $branch:expr $(,)?
+    }) => {
+        $branch
+    };
+
+    ($from:ty, {}) => {};
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,19 +206,62 @@ macro_rules! cast {
     };
 }
 
-/// Check if a value can be cast to a given concrete type.
-/// The value would equal to `cast!(value, Type).is_ok()`.
+/// Check (at compile time) whether a value of type `T` could be successfully
+/// cast to the concrete type `U` using [`cast!`].
 ///
-/// The macro is useful when a value is not `Copy` or heavy to create,
-/// and you want to avoid moving it.
+/// This macro never evaluates a value and works purely on the two type
+/// parameters you supply. It returns `true` iff `cast!(value, U)` would return
+/// `Ok(_)` for a value whose static type is `T`, subject to the same lifetime
+/// and safety restrictions documented on [`cast!`].
+///
+/// Conceptually this is equivalent to performing a trial cast, but without
+/// having (or moving) an actual value. This is useful when:
+///
+/// - You want to branch on type equality / cast feasibility inside a generic
+///   implementation without consuming a non-`Copy` value yet.
+/// - You need a simple boolean to drive other compile-time choices (e.g.
+///   selecting const generic parameters, building static lookup tables, etc.).
+/// - You are only interested in the existence of the cast, not in obtaining
+///   function pointers for both directions (see [`get_cast_fns!`]).
+///
+/// Like [`cast!`], this macro performs no data conversion – the cast only
+/// succeeds when the underlying concrete types are identical (accounting for
+/// lifetimes and the special lifetime‑free allowances). It is still “zero‑cost”
+/// after monomorphization: the compiler reduces the check to a constant.
+///
+/// # Relationship to other macros
+///
+/// - Use [`get_cast_fns!`] if you additionally need reusable function
+///   pointers for converting values in both directions.
+/// - Use [`match_ty!`] to write a chain of type match arms using
+///   `get_cast_fns!` internally.
 ///
 /// # Examples
 ///
+/// Basic checks:
 /// ```
 /// # use castaway::can_cast;
-///
-/// assert!(!can_cast!(u8, u16));
 /// assert!(can_cast!(u8, u8));
+/// assert!(!can_cast!(u8, u16));
+/// ```
+///
+/// Inside a generic context:
+/// ```
+/// use castaway::can_cast;
+///
+/// fn specializes_on_u8<T: 'static>() -> bool {
+///     can_cast!(T, u8)
+/// }
+/// assert!(specializes_on_u8::<u8>());
+/// assert!(!specializes_on_u8::<u16>());
+/// ```
+///
+/// With lifetime‑free types (no `'static` bound on the generic):
+/// ```
+/// use castaway::can_cast;
+/// fn maybe_string<T>() -> bool { can_cast!(T, String) }
+/// assert!(maybe_string::<String>());
+/// assert!(!maybe_string::<&'static str>()); // Different concrete type.
 /// ```
 #[macro_export]
 macro_rules! can_cast {
@@ -239,21 +282,71 @@ macro_rules! can_cast {
     }};
 }
 
-/// Check if a value can be cast to a given concrete type.
-/// The value would equal to `cast!(value, Type).is_ok()`.
+/// Retrieve zero‑cost function pointers that perform the cast between two
+/// concrete types `T` and `U`, if (and only if) that cast is legal per the
+/// rules of [`cast!`].
 ///
-/// The macro is useful when a value is not `Copy` or heavy to create,
-/// and you want to avoid moving it.
+/// `get_cast_fns!(T, U)` returns `Option<(fn(U) -> T, fn(T) -> U)>`.
+/// - `Some((from, to))` indicates that values of type `T` can be cast to `U`
+///   and vice‑versa (i.e. the types are considered identical for the purposes
+///   of this crate). The first function, `from`, converts a `U` into a `T`.
+///   The second function, `to`, converts a `T` into a `U`.
+/// - `None` means the cast would fail (just like `cast!(value, U)` would
+///   return `Err(value)` for a `value: T`).
+///
+/// These functions perform no runtime checks and are guaranteed to succeed
+/// when called. They are effectively identity / re‑interpretation functions
+/// that the compiler can fully inline and optimize away. Acquiring them once
+/// lets you avoid repeating the cast logic in multiple places, and can be
+/// useful for building higher‑level abstractions (see [`match_ty!`]).
+///
+/// If you only need a boolean, prefer the lighter [`can_cast!`].
+///
+/// # Ordering of the tuple
+/// The tuple is `(fn(U) -> T, fn(T) -> U)` (note the order mirrors “from U to
+/// T” first). This matches the internal implementation details and allows
+/// ergonomic pattern binding: `let (from_u, to_u) = get_cast_fns!(T, U).unwrap();`.
+///
+/// # Lifetime & safety
+/// The same lifetime restrictions apply as with [`cast!`]. The returned
+/// function pointers are always safe to call; unsafety is encapsulated within
+/// the crate once the feasibility check passes.
 ///
 /// # Examples
 ///
+/// Basic usage:
 /// ```
 /// # use castaway::get_cast_fns;
-///
 /// assert!(get_cast_fns!(u8, u16).is_none());
-/// let (from, to) = get_cast_fns!(u8, u8).unwrap();
-/// assert_eq!(from(42u8), 42u8);
-/// assert_eq!(to(42u8), 42u8);
+/// let (from_u8, to_u8) = get_cast_fns!(u8, u8).unwrap();
+/// assert_eq!(from_u8(42u8), 42u8); // U -> T (u8 -> u8)
+/// assert_eq!(to_u8(42u8), 42u8);   // T -> U
+/// ```
+///
+/// Generic specialization:
+/// ```
+/// use castaway::get_cast_fns;
+/// fn maybe_get_string_fns<T: 'static>() -> Option<(fn(String) -> T, fn(T) -> String)> {
+///     get_cast_fns!(T, String)
+/// }
+/// assert!(maybe_get_string_fns::<String>().is_some());
+/// assert!(maybe_get_string_fns::<u8>().is_none());
+/// ```
+///
+/// With a helper abstraction:
+/// ```
+/// use castaway::get_cast_fns;
+/// fn transform_if_same<T: 'static, U: 'static>(value: T, f: impl FnOnce(U) -> U) -> T {
+///     if let Some((from_u, to_u)) = get_cast_fns!(T, U) {
+///         // Safe: we know T == U for casting purposes.
+///         let u_val = to_u(value); // T -> U
+///         from_u(f(u_val))         // U -> T
+///     } else {
+///         value
+///     }
+/// }
+/// assert_eq!(transform_if_same::<u8, u8>(5, |x| x + 1), 6);
+/// assert_eq!(transform_if_same::<u8, u16>(5, |x| x + 1), 5);
 /// ```
 #[macro_export]
 macro_rules! get_cast_fns {
@@ -460,7 +553,10 @@ mod tests {
     #[test]
     fn cast_lifetime_free_unsized_ref() {
         fn can_cast<T>(value: &[T]) -> bool {
-            cast!(value, &[u8]).is_ok()
+            let result = cast!(value, &[u8]).is_ok();
+            assert_eq!(result, can_cast!(T, u8));
+            assert_eq!(result, get_cast_fns!(T, u8).is_some());
+            result
         }
 
         let value = 42i32;
@@ -472,7 +568,10 @@ mod tests {
     #[test]
     fn cast_lifetime_free_unsized_mut() {
         fn can_cast<T>(value: &mut [T]) -> bool {
-            cast!(value, &mut [u8]).is_ok()
+            let result = cast!(value, &mut [u8]).is_ok();
+            assert_eq!(result, can_cast!(T, u8));
+            assert_eq!(result, get_cast_fns!(T, u8).is_some());
+            result
         }
 
         let value = 42i32;
@@ -563,7 +662,10 @@ mod tests {
                 #[allow(non_snake_case)]
                 fn [<cast_lifetime_free_ $TARGET>]() {
                     fn do_cast<T>(value: T) -> Result<$TARGET, T> {
-                        cast!(value, $TARGET)
+                        let result = cast!(value, $TARGET);
+                        assert_eq!(result.is_ok(), can_cast!(T, $TARGET));
+                        assert_eq!(result.is_ok(), get_cast_fns!(T, $TARGET).is_some());
+                        result
                     }
 
                     $(
@@ -579,7 +681,10 @@ mod tests {
                 #[allow(non_snake_case)]
                 fn [<cast_lifetime_free_ref_ $TARGET>]() {
                     fn do_cast<T>(value: &T) -> Result<&$TARGET, &T> {
-                        cast!(value, &$TARGET)
+                        let result = cast!(value, &$TARGET);
+                        assert_eq!(result.is_ok(), can_cast!(T, $TARGET));
+                        assert_eq!(result.is_ok(), get_cast_fns!(T, $TARGET).is_some());
+                        result
                     }
 
                     $(
@@ -595,7 +700,10 @@ mod tests {
                 #[allow(non_snake_case)]
                 fn [<cast_lifetime_free_mut_ $TARGET>]() {
                     fn do_cast<T>(value: &mut T) -> Result<&mut $TARGET, &mut T> {
-                        cast!(value, &mut $TARGET)
+                        let result = cast!(value, &mut $TARGET);
+                        assert_eq!(result.is_ok(), can_cast!(T, $TARGET));
+                        assert_eq!(result.is_ok(), get_cast_fns!(T, $TARGET).is_some());
+                        result
                     }
 
                     $(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,39 +446,155 @@ macro_rules! match_type {
 }
 
 #[macro_export]
+/// Perform a compile-time style match over a single source type against one or
+/// more candidate destination types, executing the first matching branch.
+///
+/// This macro is the type-level analogue to [`match_type!`], but instead of
+/// matching on the runtime value of an expression it matches only on the
+/// *static type* `From` that you provide as the first argument. Each arm lists
+/// one or more concrete destination types separated by `|`. If any of those
+/// types can be (symmetrically) cast to/from `From` (i.e. they are considered
+/// identical under the rules of this crate), the associated branch expression
+/// is evaluated and returned as the overall result of the macro invocation.
+///
+/// Internally this uses [`get_cast_fns!`] to test feasibility. Branches that
+/// are not taken compile away entirely; there is no runtime branching once
+/// monomorphized. Like the other casting macros, no data conversion is
+/// performed—only identity casts for concretely equal types (respecting
+/// lifetime / lifetime‑free rules) are considered matches.
+///
+/// A final default arm is required (unless you intentionally invoke with an
+/// empty set, which expands to `()`), because you cannot exhaustively list all
+/// possible types. The default arm does not have to be `_`; any irrefutable
+/// pattern is accepted. Since no value is supplied, that pattern is typically
+/// just `_`.
+///
+/// Differences from [`match_type!`]:
+/// - `match_ty!` operates purely on types; it never evaluates or binds a
+///   value.
+/// - Branch arms cannot directly bind a value of the matched type (there is
+///   none); they just produce an expression result.
+/// - It returns the branch expression directly; there is no intermediate cast
+///   `Result`.
+///
+/// If you need the actual *cast functions* inside the matched branch, simply
+/// call `get_cast_fns!(From, ThatType).unwrap()` again inside that branch; the
+/// compiler will constant-propagate the unwrap because the macro already
+/// proved the types match.
+///
+/// # Examples
+///
+/// Basic categorization:
+/// ```
+/// use castaway::match_ty;
+/// fn classify<T: 'static>() -> &'static str {
+///     match_ty!(T, {
+///         u8 | i8 => "byte",
+///         u16 => "short",
+///         _ => "other",
+///     })
+/// }
+/// assert_eq!(classify::<u8>(), "byte");
+/// assert_eq!(classify::<i8>(), "byte");
+/// assert_eq!(classify::<u16>(), "short");
+/// assert_eq!(classify::<u32>(), "other");
+/// ```
+///
+/// Using it to specialize a generic implementation:
+/// ```
+/// use castaway::match_ty;
+/// fn zero_value<T: 'static>() -> T where T: Default {
+///     match_ty!(T, (from, _), {
+///         u8 => from(0u8),
+///         i32 => from(0i32),
+///         // Fall back to `Default` for any other type.
+///         _ => T::default(),
+///     })
+/// }
+/// assert_eq!(zero_value::<u8>(), 0);
+/// assert_eq!(zero_value::<i32>(), 0);
+/// assert_eq!(zero_value::<u16>(), 0); // from Default
+/// ```
+///
+/// Accessing cast function pointers inside a matched branch:
+/// ```
+/// use castaway::match_ty;
+/// fn maybe_round_trip<T: 'static + Copy>() -> Option<(fn(u32)->T, fn(T)->u32)> {
+///     match_ty!(T, (from, to), {
+///         u32 => {
+///             Some((from, to))
+///         },
+///         _ => None,
+///     })
+/// }
+/// assert!(maybe_round_trip::<u32>().is_some());
+/// assert!(maybe_round_trip::<u16>().is_none());
+/// ```
+///
+/// Empty usage (rare):
+/// ```
+/// use castaway::match_ty;
+/// const _: () = match_ty!(u8, {}); // Expands to ()
+/// ```
+///
+/// # Pitfalls
+/// - Remember to include a default arm, otherwise you may accidentally rely
+///   on the empty-form which just returns `()`.
+/// - Grouping with `|` shares a single branch expression for all types in the
+///   group; if you need different logic per type, use separate arms.
+/// - Lifetimes and lifetime‑free rules apply just as with [`cast!`]; if a cast
+///   would be rejected there, the arm will not match here.
+///
+/// # When to use
+/// - You need a concise, readable way to pick between a small set of known
+///   concrete types in a generic context.
+/// - You want zero‑cost pseudo‑specialization without nightly features.
 macro_rules! match_ty {
+    ($from:ty, $(($from_fn:pat, $to_fn:pat),)? {
+        _ => $branch:expr $(,)?
+    }) => {
+        ($branch)
+    };
+
+    ($from:ty, ($from_fn:pat, $to_fn:pat), {
+        $to:ty $(| $to_tail:ty)* => $branch:expr,
+        $($tail:tt)*
+    }) => {
+        if let Some(($from_fn, $to_fn)) = $crate::get_cast_fns!($from, $to) {
+            $branch
+        } else {
+            $crate::match_ty!($from, ($from_fn, $to_fn), {
+                $($to_tail => $branch,)*
+                $($tail)*
+            })
+        }
+    };
+
     ($from:ty, {
         $to:ty $(| $to_tail:ty)* => $branch:expr,
         $($tail:tt)*
     }) => {
-        $crate::match_ty!($from, {
-            | $to => $branch,
-            $(| $to_tail:ty => $branch,)*
+        if $crate::can_cast!($from, $to) {
+            $branch
+        } else {
+            $crate::match_ty!($from, {
+                $($to_tail => $branch,)*
+                $($tail)*
+            })
+        }
+    };
+
+    ($from:ty, $(($from_fn:pat, $to_fn:pat),)? {
+        $(| $to:ty)+ => $branch:expr,
+        $($tail:tt)*
+    }) => {
+        $crate::match_ty!($from, $(($from_fn, $to_fn),)? {
+            $($to => $branch,)+
             $($tail)*
         });
     };
 
-    ($from:ty, {
-        | $to:ty $(| $to_tail:ty)* => $branch:expr,
-        $($tail:tt)*
-    }) => {{
-        if let Some((from, to)) = get_cast_fns!($from, $to) {
-            $branch
-        } else {
-            $crate::match_ty!($from, {
-                $(| $to_tail:ty => $branch,)*
-                $($tail)*
-            });
-        }
-    }};
-
-    ($from:ty, {
-        $pat:pat => $branch:expr $(,)?
-    }) => {
-        $branch
-    };
-
-    ($from:ty, {}) => {};
+    ($from:ty, $(($from_fn:pat, $to_fn:pat),)? {}) => {()};
 }
 
 #[cfg(test)]
@@ -778,5 +894,14 @@ mod tests {
             (false, 2u16) => Ok((false, 2u16)),
             true => Err(true),
         }
+    }
+
+    #[test]
+    fn test_match_ty() {
+        let a = match_ty!(u8, {
+            u8 => 1,
+            _ => 2,
+        });
+        assert_eq!(a, 1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -450,40 +450,59 @@ macro_rules! match_type {
 /// more candidate destination types, executing the first matching branch.
 ///
 /// This macro is the type-level analogue to [`match_type!`], but instead of
-/// matching on the runtime value of an expression it matches only on the
-/// *static type* `From` that you provide as the first argument. Each arm lists
-/// one or more concrete destination types separated by `|`. If any of those
-/// types can be (symmetrically) cast to/from `From` (i.e. they are considered
-/// identical under the rules of this crate), the associated branch expression
-/// is evaluated and returned as the overall result of the macro invocation.
+/// matching on the runtime value of an expression it examines only the *static
+/// type* `From` (the first argument). Each arm lists one or more concrete
+/// destination types separated by `|`. If any of those destination types can
+/// be (symmetrically) cast to/from `From` (i.e. they are identical under this
+/// crate's rules), the corresponding branch expression is evaluated and its
+/// value becomes the macro's result.
 ///
-/// Internally this uses [`get_cast_fns!`] to test feasibility. Branches that
-/// are not taken compile away entirely; there is no runtime branching once
-/// monomorphized. Like the other casting macros, no data conversion is
-/// performed—only identity casts for concretely equal types (respecting
-/// lifetime / lifetime‑free rules) are considered matches.
+/// Internally this uses [`can_cast!`] (fast path) and/or [`get_cast_fns!`]
+/// (when you request the function pointers) to test feasibility. Untaken
+/// branches compile away completely; there is no runtime overhead after
+/// monomorphization. No data transformation occurs: only identity casts for
+/// concretely equal types (respecting lifetime / lifetime‑free constraints)
+/// are considered matches.
 ///
-/// A final default arm is required (unless you intentionally invoke with an
-/// empty set, which expands to `()`), because you cannot exhaustively list all
-/// possible types. The default arm does not have to be `_`; any irrefutable
-/// pattern is accepted. Since no value is supplied, that pattern is typically
-/// just `_`.
+/// # Syntax
+/// Basic form (boolean style matching on type only):
+/// ```text
+/// match_ty!(From, {
+///     Type1 => expr1,
+///     Type2 | Type3 => expr2,
+///     _ => default_expr,
+/// })
+/// ```
+/// A leading `|` before the first type in an arm (`| Type1 | Type2 => ...`) is
+/// also accepted for stylistic consistency with normal Rust pattern groups.
 ///
-/// Differences from [`match_type!`]:
-/// - `match_ty!` operates purely on types; it never evaluates or binds a
-///   value.
-/// - Branch arms cannot directly bind a value of the matched type (there is
-///   none); they just produce an expression result.
-/// - It returns the branch expression directly; there is no intermediate cast
-///   `Result`.
+/// Function‑capturing form (obtain zero‑cost cast function pointers):
+/// ```text
+/// match_ty!(From, (from_fn, to_fn), {
+///     TargetType => expr_using_from_fn_and_to_fn,
+///     _ => fallback,
+/// })
+/// ```
+/// In a matching arm, `from_fn` has type `fn(TargetType) -> From` and `to_fn`
+/// has type `fn(From) -> TargetType`. In non‑matching arms those names are not
+/// bound (the code for that arm is never executed anyway). You may ignore one
+/// of them with `_`.
 ///
-/// If you need the actual *cast functions* inside the matched branch, simply
-/// call `get_cast_fns!(From, ThatType).unwrap()` again inside that branch; the
-/// compiler will constant-propagate the unwrap because the macro already
-/// proved the types match.
+/// An entirely empty arm set is permitted: `match_ty!(T, {})` expands to `()`.
+/// A final default arm (`_ => ...`) is otherwise required because you cannot
+/// enumerate all possible types.
+///
+/// # Differences from [`match_type!`]
+/// - Operates only on types; no value is evaluated or bound.
+/// - Branch expressions cannot pattern‑match on a value of the matched type.
+/// - Directly returns the branch expression (no intermediate `Result`).
+///
+/// # Captured function pointer ordering
+/// The tuple captured internally (and exposed via your `(from_fn, to_fn)`
+/// pattern) is `(fn(Target) -> From, fn(From) -> Target)`. Naming them `from`
+/// and `to` is a common convention used in the examples below.
 ///
 /// # Examples
-///
 /// Basic categorization:
 /// ```
 /// use castaway::match_ty;
@@ -500,30 +519,27 @@ macro_rules! match_type {
 /// assert_eq!(classify::<u32>(), "other");
 /// ```
 ///
-/// Using it to specialize a generic implementation:
+/// Specializing while capturing cast functions (note `_` ignores the second):
 /// ```
 /// use castaway::match_ty;
-/// fn zero_value<T: 'static>() -> T where T: Default {
+/// fn default_value<T: 'static + Default>() -> T {
 ///     match_ty!(T, (from, _), {
-///         u8 => from(0u8),
-///         i32 => from(0i32),
-///         // Fall back to `Default` for any other type.
+///         u8 => from(1u8),
+///         i32 => from(2i32),
 ///         _ => T::default(),
 ///     })
 /// }
-/// assert_eq!(zero_value::<u8>(), 0);
-/// assert_eq!(zero_value::<i32>(), 0);
-/// assert_eq!(zero_value::<u16>(), 0); // from Default
+/// assert_eq!(default_value::<u8>(), 1);
+/// assert_eq!(default_value::<i32>(), 2);
+/// assert_eq!(default_value::<u16>(), 0); // via Default
 /// ```
 ///
-/// Accessing cast function pointers inside a matched branch:
+/// Accessing both conversion directions directly:
 /// ```
 /// use castaway::match_ty;
 /// fn maybe_round_trip<T: 'static + Copy>() -> Option<(fn(u32)->T, fn(T)->u32)> {
 ///     match_ty!(T, (from, to), {
-///         u32 => {
-///             Some((from, to))
-///         },
+///         u32 => Some((from, to)),
 ///         _ => None,
 ///     })
 /// }
@@ -536,19 +552,6 @@ macro_rules! match_type {
 /// use castaway::match_ty;
 /// const _: () = match_ty!(u8, {}); // Expands to ()
 /// ```
-///
-/// # Pitfalls
-/// - Remember to include a default arm, otherwise you may accidentally rely
-///   on the empty-form which just returns `()`.
-/// - Grouping with `|` shares a single branch expression for all types in the
-///   group; if you need different logic per type, use separate arms.
-/// - Lifetimes and lifetime‑free rules apply just as with [`cast!`]; if a cast
-///   would be rejected there, the arm will not match here.
-///
-/// # When to use
-/// - You need a concise, readable way to pick between a small set of known
-///   concrete types in a generic context.
-/// - You want zero‑cost pseudo‑specialization without nightly features.
 macro_rules! match_ty {
     ($from:ty, $(($from_fn:pat, $to_fn:pat),)? {
         _ => $branch:expr $(,)?
@@ -900,6 +903,20 @@ mod tests {
     fn test_match_ty() {
         let a = match_ty!(u8, {
             u8 => 1,
+            _ => 2,
+        });
+        assert_eq!(a, 1);
+
+        let a = match_ty!(u16, (from, _), {
+            u8 => from(1),
+            u16 => from(2),
+            _ => 3,
+        });
+        assert_eq!(a, 2);
+
+
+        let a = match_ty!(u16, (from, _), {
+            u8 | u16 => from(1),
             _ => 2,
         });
         assert_eq!(a, 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,6 +580,35 @@ mod tests {
         assert!(!can_cast(&mut [&value, &value]));
     }
 
+    macro_rules! test_cast_inner {
+        (@mut $value:expr, $T:ty, $U:ty) => {{
+            let mut value_src = $value.clone();
+            let result = cast!($value, $U);
+            assert_eq!(result.is_ok(), can_cast!($T, $U));
+            assert_eq!(result.is_ok(), get_cast_fns!($T, $U).is_some());
+            if let Some((from, to)) = get_cast_fns!($T, $U) {
+                let value_t = from(result.unwrap()); // U -> T
+                assert_eq!(value_t, &mut value_src);
+                Ok(to(value_t)) // T -> U
+            } else {
+                result
+            }
+        }};
+        ($value:expr, $T:ty, $U:ty) => {{
+            let value_src: $T = $value.clone();
+            let result = cast!($value, $U);
+            assert_eq!(result.is_ok(), can_cast!($T, $U));
+            assert_eq!(result.is_ok(), get_cast_fns!($T, $U).is_some());
+            if let Some((from, to)) = get_cast_fns!($T, $U) {
+                let value_in: $T = value_src.clone();
+                let value_u = to(value_in); // T -> U
+                let value_t = from(value_u); // U -> T
+                assert_eq!(value_t, value_src);
+            }
+            result
+        }};
+    }
+
     macro_rules! test_lifetime_free_cast {
         () => {};
 
@@ -597,8 +626,8 @@ mod tests {
                 #[test]
                 #[allow(non_snake_case)]
                 fn [<cast_lifetime_free_ $name>]() {
-                    fn do_cast<T>(value: T) -> Result<$TARGET, T> {
-                        cast!(value, $TARGET)
+                    fn do_cast<T: Clone + PartialEq + std::fmt::Debug>(value: T) -> Result<$TARGET, T> {
+                        test_cast_inner!(value, T, $TARGET)
                     }
 
                     $(
@@ -613,8 +642,8 @@ mod tests {
                 #[test]
                 #[allow(non_snake_case)]
                 fn [<cast_lifetime_free_ref_ $name>]() {
-                    fn do_cast<T>(value: &T) -> Result<&$TARGET, &T> {
-                        cast!(value, &$TARGET)
+                    fn do_cast<'a, T: PartialEq + std::fmt::Debug>(value: &'a T) -> Result<&'a $TARGET, &'a T> {
+                        test_cast_inner!(value, &'a T, &'a $TARGET)
                     }
 
                     $(
@@ -629,8 +658,8 @@ mod tests {
                 #[test]
                 #[allow(non_snake_case)]
                 fn [<cast_lifetime_free_mut_ $name>]() {
-                    fn do_cast<T>(value: &mut T) -> Result<&mut $TARGET, &mut T> {
-                        cast!(value, &mut $TARGET)
+                    fn do_cast<'a, T: Clone + PartialEq + std::fmt::Debug>(value: &'a mut T) -> Result<&'a mut $TARGET, &'a mut T> {
+                        test_cast_inner!(@mut value, &'a mut T, &'a mut $TARGET)
                     }
 
                     $(
@@ -661,11 +690,8 @@ mod tests {
                 #[test]
                 #[allow(non_snake_case)]
                 fn [<cast_lifetime_free_ $TARGET>]() {
-                    fn do_cast<T>(value: T) -> Result<$TARGET, T> {
-                        let result = cast!(value, $TARGET);
-                        assert_eq!(result.is_ok(), can_cast!(T, $TARGET));
-                        assert_eq!(result.is_ok(), get_cast_fns!(T, $TARGET).is_some());
-                        result
+                    fn do_cast<T: Clone + PartialEq + std::fmt::Debug>(value: T) -> Result<$TARGET, T> {
+                        test_cast_inner!(value, T, $TARGET)
                     }
 
                     $(
@@ -680,11 +706,8 @@ mod tests {
                 #[test]
                 #[allow(non_snake_case)]
                 fn [<cast_lifetime_free_ref_ $TARGET>]() {
-                    fn do_cast<T>(value: &T) -> Result<&$TARGET, &T> {
-                        let result = cast!(value, &$TARGET);
-                        assert_eq!(result.is_ok(), can_cast!(T, $TARGET));
-                        assert_eq!(result.is_ok(), get_cast_fns!(T, $TARGET).is_some());
-                        result
+                    fn do_cast<'a, T: PartialEq + std::fmt::Debug>(value: &'a T) -> Result<&'a $TARGET, &'a T> {
+                        test_cast_inner!(value, &'a T, &'a $TARGET)
                     }
 
                     $(
@@ -699,11 +722,8 @@ mod tests {
                 #[test]
                 #[allow(non_snake_case)]
                 fn [<cast_lifetime_free_mut_ $TARGET>]() {
-                    fn do_cast<T>(value: &mut T) -> Result<&mut $TARGET, &mut T> {
-                        let result = cast!(value, &mut $TARGET);
-                        assert_eq!(result.is_ok(), can_cast!(T, $TARGET));
-                        assert_eq!(result.is_ok(), get_cast_fns!(T, $TARGET).is_some());
-                        result
+                    fn do_cast<'a, T: Clone + PartialEq + std::fmt::Debug>(value: &'a mut T) -> Result<&'a mut $TARGET, &'a mut T> {
+                        test_cast_inner!(@mut value, &'a mut T, &'a mut $TARGET)
                     }
 
                     $(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -336,7 +336,7 @@ macro_rules! can_cast {
 /// With a helper abstraction:
 /// ```
 /// use castaway::get_cast_fns;
-/// fn transform_if_same<T: 'static, U: 'static>(value: T, f: impl FnOnce(U) -> U) -> T {
+/// fn transform_if_same<T: 'static, U: 'static, F: FnOnce(U) -> U>(value: T, f: F) -> T {
 ///     if let Some((from_u, to_u)) = get_cast_fns!(T, U) {
 ///         // Safe: we know T == U for casting purposes.
 ///         let u_val = to_u(value); // T -> U
@@ -345,8 +345,8 @@ macro_rules! can_cast {
 ///         value
 ///     }
 /// }
-/// assert_eq!(transform_if_same::<u8, u8>(5, |x| x + 1), 6);
-/// assert_eq!(transform_if_same::<u8, u16>(5, |x| x + 1), 5);
+/// assert_eq!(transform_if_same::<u8, u8, _>(5, |x| x + 1), 6);
+/// assert_eq!(transform_if_same::<u8, u16, _>(5, |x| x + 1), 5);
 /// ```
 #[macro_export]
 macro_rules! get_cast_fns {


### PR DESCRIPTION
Fixes #35.

This PR is based on #36, I'd like to perform rebase when #36 landed.

* add `try_cast_from`, `get_cast_fns` for `TryCast*`
* every `TryCast` trait should implemented `CAST_METHOD` (just for test, tell which trait is actually calling on), `can_cast`, `unchecked_from` and `unchecked_to`, other methods would derived from these methods
* add `can_cast!`, `get_cast_fns!` and `match_ty!` macros

```rust
type From = u8;
type To = u8;

assert!(can_cast!(From, To));

if let Some((from, to)) = get_cast_fns!(From, To) {
  assert_eq!(from(1), 1);
  assert_eq!(to(1), 1);
}

let result: From = match_ty!(To, {
  u8 => from(1u8),
  u16 => from(2u16), // this would never called
  _ => unreachable!()
});
```

It would be better naming
* current `match_type` to `match_cast`
* and `match_ty` in this PR to `match_type`

But for non-breaking change, we naming it `match_ty`